### PR TITLE
Improve imports of STOP_WORDS in tests, example usage of black code formatter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ venv
 env
 *.pyc
 .eggs
+.vscode/*
 
 # Documentation #
 docs/build

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PIP := $(shell command -v pip 2> /dev/null || command which pip 2> /dev/null)
 PYTHON := $(shell command -v python3 2> /dev/null || command which python 2> /dev/null)
 
-.PHONY: install dev-install install_conda dev-install_conda tests doc docupdate
+.PHONY: install dev-install install_conda dev-install_conda tests doc docupdate clean-pyc
 
 pipcheck:
 ifndef PIP

--- a/enlp/understanding/distributions.py
+++ b/enlp/understanding/distributions.py
@@ -66,7 +66,7 @@ def compute_tfidf(text_list, doc_ids=None):
     words = vectorizer.get_feature_names()
     doc_dicts = []
 
-    for i, doc_scores in enumerate(X):
+    for _, doc_scores in enumerate(X):
         doc_dict = dict()
         for w_i, w_v in enumerate(doc_scores.toarray()[0]):
             doc_dict.update({words[w_i]: w_v})

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,3 +19,4 @@ nbsphinx
 image
 wordcloud
 rake-nltk
+black

--- a/tests/processing/test_get_stopwords.py
+++ b/tests/processing/test_get_stopwords.py
@@ -1,4 +1,6 @@
 import pytest
+from spacy.lang.en.stop_words import STOP_WORDS as STOP_WORDS_EN
+from spacy.lang.nb.stop_words import STOP_WORDS as STOP_WORDS_NB
 
 # Explicitly set path so don't need to run setup.py - if we have multiple copies of the code we would otherwise need
 # to setup a separate environment for each to ensure the code pointers are correct.
@@ -9,8 +11,7 @@ from enlp.processing.stdtools import get_stopwords
 
 def test_get_stopwords_english():
     # arrange - get stopwords outwith function
-    from spacy.lang.en.stop_words import STOP_WORDS
-    stops_en_direct = list(STOP_WORDS)
+    stops_en_direct = list(STOP_WORDS_EN)
     
     # act - get functions idea of stopwords
     stopwords_func, stopwords_nb_func, stopwords_en_func = get_stopwords()
@@ -21,8 +22,7 @@ def test_get_stopwords_english():
 
 def test_get_stopwords_norwegian():
     # arrange - get stopwords outwith function
-    from spacy.lang.nb.stop_words import STOP_WORDS
-    stops_nb_direct = list(STOP_WORDS)
+    stops_nb_direct = list(STOP_WORDS_NB)
 
     # act - get functions idea of stopwords
     stopwords_func, stopwords_nb_func, _ = get_stopwords()
@@ -33,11 +33,8 @@ def test_get_stopwords_norwegian():
 
 def test_get_stopwords_full():
     # arrange - get stopwords outwith function
-    from spacy.lang.en.stop_words import STOP_WORDS
-    stops_en_direct = list(STOP_WORDS)
-
-    from spacy.lang.nb.stop_words import STOP_WORDS
-    stops_nb_direct = list(STOP_WORDS)
+    stops_en_direct = list(STOP_WORDS_EN)
+    stops_nb_direct = list(STOP_WORDS_NB)
 
     stopwords = stops_en_direct + stops_nb_direct
     stopwords_direct = [str(i) for i in stopwords]

--- a/tests/processing/test_tokenise.py
+++ b/tests/processing/test_tokenise.py
@@ -1,31 +1,37 @@
 import pytest
 import spacy
-
 from enlp.processing.stdtools import tokenise
 
 
 @pytest.fixture(scope="module")
 def norwegian_language_model():
-    return spacy.load('nb_dep_ud_sm')
+    return spacy.load("nb_dep_ud_sm")
 
 
 @pytest.fixture(scope="module")
 def english_language_model():
-    return spacy.load('en_core_web_md')
+    return spacy.load("en_core_web_md")
+
 
 # ENGLISH
-@pytest.mark.parametrize("english_language_model,text,expectedoutput",
-                         [pytest.param(english_language_model,
-                                       'the quick brown fox jumped over the lazy dog',
-                                       ['the', 'quick', 'brown', 'fox', 'jumped', 'over', 'the', 'lazy', 'dog'],
-                                       id='en_test1_simple'),
-                          pytest.param(english_language_model,
-                                       'oak is strong and also gives shade',
-                                       ['oak', 'is', 'strong', 'and', 'also', 'gives', 'shade'],
-                                       id='en_test2_simple'),
-                          ],
-                         indirect=['english_language_model'],
-                         )
+@pytest.mark.parametrize(
+    "english_language_model,text,expectedoutput",
+    [
+        pytest.param(
+            english_language_model,
+            "the quick brown fox jumped over the lazy dog",
+            ["the", "quick", "brown", "fox", "jumped", "over", "the", "lazy", "dog"],
+            id="en_test1_simple",
+        ),
+        pytest.param(
+            english_language_model,
+            "oak is strong and also gives shade",
+            ["oak", "is", "strong", "and", "also", "gives", "shade"],
+            id="en_test2_simple",
+        ),
+    ],
+    indirect=["english_language_model"],
+)
 def test_tokenise_en(english_language_model, text, expectedoutput):
     # arange - not needed
 
@@ -37,18 +43,34 @@ def test_tokenise_en(english_language_model, text, expectedoutput):
 
 
 # NORWEGIAN
-@pytest.mark.parametrize("norwegian_language_model,text,expectedoutput",
-                         [pytest.param(norwegian_language_model,
-                                       'den raske brune reven hoppet over den late hunden',
-                                       ['den', 'raske', 'brune', 'reven', 'hoppet', 'over', 'den', 'late', 'hunden'],
-                                       id='no_test1_simple'),
-                          pytest.param(norwegian_language_model,
-                                       'eiken er sterk og gir også skygge',
-                                       ['eiken', 'er', 'sterk', 'og', 'gir', 'også', 'skygge'],
-                                       id='no_test2_simple'),
-                          ],
-                         indirect=['norwegian_language_model'],
-                         )
+@pytest.mark.parametrize(
+    "norwegian_language_model,text,expectedoutput",
+    [
+        pytest.param(
+            norwegian_language_model,
+            "den raske brune reven hoppet over den late hunden",
+            [
+                "den",
+                "raske",
+                "brune",
+                "reven",
+                "hoppet",
+                "over",
+                "den",
+                "late",
+                "hunden",
+            ],
+            id="no_test1_simple",
+        ),
+        pytest.param(
+            norwegian_language_model,
+            "eiken er sterk og gir også skygge",
+            ["eiken", "er", "sterk", "og", "gir", "også", "skygge"],
+            id="no_test2_simple",
+        ),
+    ],
+    indirect=["norwegian_language_model"],
+)
 def test_tokenise_no(norwegian_language_model, text, expectedoutput):
     # arange - not needed
 


### PR DESCRIPTION
Hei,

This PR contains:
- the same changes to imports of STOP_WORDS in `test_get_stopwords.py` as in `stdtools.py`,
- added `clean-pyc` to .PHONY in the Makefile,
- Presumably a fix to a codacy issue of a unused variable (used `_` instead of `i` for unused index in `enumerate`), not sure if this will work, but it will not harm,
- An example of the results of using a code formatter, all changes in `test_tokenize.py` are created by running `black tests/processing/test_tokenise.py`. I think it improves code readability.

Several other projects at Equinor use the Black formatter for python code, for example:
- <https://github.com/equinor/webviz-config>, and
- <https://github.com/equinor/semeio>

I think it is possible to run this formatter as a github action (it would not actually do code changes, but just notify if the formatter has not been run prior to a commit. I have never done it, but sure we would figure it out).

Running the formatter on the whole code might leave other people working on the code with merge conflict, but these could supposedly be solved by them by running the same formatter themselves.

Let me know what you think about using the Black code formatter.

Regards,
Rafael